### PR TITLE
make unitfile independent of docker.service

### DIFF
--- a/systemd/docker-novolume-plugin.service
+++ b/systemd/docker-novolume-plugin.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Docker No volumes authZ Plugin
 Documentation=man:docker-novolume-plugin(8)
-Before=docker.service
 After=network.target docker-novolume-plugin.socket
-Requires=docker-novolume-plugin.socket docker.service
+Requires=docker-novolume-plugin.socket
 
 [Service]
 # might need to set flags...


### PR DESCRIPTION
This allows both docker and docker-latest to use novolume-plugin without any
changes in novolume-plugin's unitfile.

Instead docker and docker-latest's unitfiles will have a dependency on
docker-novolume-plugin like so:

After=docker-novolume-plugin.socket
Wants=docker-novolume-plugin.socket

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org
